### PR TITLE
Enable aarch64 build

### DIFF
--- a/com.jetbrains.PhpStorm.json
+++ b/com.jetbrains.PhpStorm.json
@@ -127,6 +127,24 @@
                     "url": "https://download.jetbrains.com/webide/PhpStorm-2023.1.4.tar.gz",
                     "sha256": "7b44d704641c6015ce49e12e82c8866e9fdd8e8d421590235e536b3b1312b180",
                     "size": 648953340,
+                    "only-arches": [
+                        "x86_64"
+                    ],
+                    "x-checker-data": {
+                        "type": "jetbrains",
+                        "code": "PS",
+                        "is-main-source": true
+                    }
+                },
+                {
+                    "type": "extra-data",
+                    "filename": "phpstorm.tar.gz",
+                    "url": "https://download.jetbrains.com/webide/PhpStorm-2023.1.4-aarch64.tar.gz",
+                    "sha256": "18ec9ee5ef5b81456afbe9ad12f2ea303e55793135b9b44dc28f70207fa717f9",
+                    "size": 645475495,
+                    "only-arches": [
+                        "aarch64"
+                    ],
                     "x-checker-data": {
                         "type": "jetbrains",
                         "code": "PS",

--- a/flathub.json
+++ b/flathub.json
@@ -1,5 +1,5 @@
 {
   "publish-delay-hours": 1,
-  "only-arches": ["x86_64"],
+  "only-arches": ["x86_64", "aarch64"],
   "require-important-update": true
 }


### PR DESCRIPTION
See also:
- https://github.com/flathub/com.jetbrains.GoLand/pull/71
- https://github.com/flathub/com.jetbrains.GoLand/pull/72 fedc updating both x86_64 and aarch64 sources with no issues

Fixes #71 

Tested on Asahi Linux