### PR TITLE
Add PhpStorm tool configuration to JSON

### DIFF
--- a/com.jetbrains.PhpStorm.json
+++ b/com.jetbrains.PhpStorm.json
@@ -101,7 +101,8 @@
                 "install -Dm0644 -t ${FLATPAK_DEST}/share/metainfo/ ${FLATPAK_ID}.metainfo.xml",
                 "install -Dm0755 entrypoint.sh ${FLATPAK_DEST}/bin/entrypoint",
                 "install -Dm0755 apply_extra.sh ${FLATPAK_DEST}/bin/apply_extra",
-                "cat idea.properties | tee -a ${FLATPAK_DEST}/bin/idea.properties"
+                "cat idea.properties | tee -a ${FLATPAK_DEST}/bin/idea.properties",
+                "mkdir -p /app/tools"
             ],
             "sources": [
                 {


### PR DESCRIPTION
This will hopefully provide `/app/tools` integration, like supported with VSCode.

I'm testing this at the moment:

<img width="1514" height="1138" alt="image" src="https://github.com/user-attachments/assets/17ee656c-ab5c-4b55-8295-c5d3d1fb993a" />
