### PR TITLE
Add PhpStorm tool configuration to JSON

### DIFF
--- a/com.jetbrains.PhpStorm.json
+++ b/com.jetbrains.PhpStorm.json
@@ -25,6 +25,15 @@
         "--talk-name=org.freedesktop.Flatpak",
         "--talk-name=org.gnome.keyring.SystemPrompter"
     ],
+    "add-extensions": {
+        "com.jetbrains.PhpStorm.tool": {
+            "directory": "tools",
+            "subdirectories": true,
+            "version": "24.08",
+            "add-ld-path": "lib",
+            "no-autodownload": true
+        }
+    },
     "modules": [
         "shared-modules/libsecret/libsecret.json",
         {

--- a/com.jetbrains.PhpStorm.json
+++ b/com.jetbrains.PhpStorm.json
@@ -99,7 +99,8 @@
                 "install -Dm0644 -t ${FLATPAK_DEST}/share/applications/ ${FLATPAK_ID}.desktop",
                 "install -Dm0644 -t ${FLATPAK_DEST}/share/metainfo/ ${FLATPAK_ID}.metainfo.xml",
                 "install -Dm0755 apply_extra ${FLATPAK_DEST}/bin/apply_extra",
-                "cat idea.properties | tee -a ${FLATPAK_DEST}/bin/idea.properties"
+                "cat idea.properties | tee -a ${FLATPAK_DEST}/bin/idea.properties",
+                "mkdir -p /app/tools"
             ],
             "sources": [
                 {


### PR DESCRIPTION
The previous PR was closed, but didn't add the tools directory.

This PR introduces tools support, e.g. com.jetbrains.PhpStorm.tool.podman (I want to submit this to Flathub - https://github.com/francoism90/com.jetbrains.PhpStorm.tool.podman), etc.

<img width="1514" height="1138" alt="image" src="https://github.com/user-attachments/assets/17ee656c-ab5c-4b55-8295-c5d3d1fb993a" />
