### PR TITLE
Remove only-arches limitation

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,5 +1,4 @@
 {
   "publish-delay-hours": 1,
-  "only-arches": ["x86_64", "aarch64"],
   "require-important-update": true
 }


### PR DESCRIPTION
Since both are listed, simply remove the "only-arches" limitations.

See: https://docs.flathub.org/docs/for-app-authors/maintenance#limiting-the-set-of-architectures-to-build-on

> If you build for both x86_64 and aarch64 you do not need a flathub.json file. There will be no new architecture add or removed on current runtimes, which mean that if that situation ever occurred, it would only happen when changing the runtime version in your package.